### PR TITLE
Harden SDK logging, HTTP defaults, and CI supply chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 This API wrapper contains methods for interacting easily with ZeroBounce API.
 More information about ZeroBounce you can find in the [official documentation](https://www.zerobounce.net/docs/).
 
+
+## Security
+
+- Keep API keys on a trusted server. Do not embed them in mobile apps or browser JavaScript that untrusted users can inspect.
+- Custom API base URLs (when supported) must use `https://`. Do not pass end-user-controlled hosts into those settings.
+- Request URLs include `api_key` as a query parameter (ZeroBounce API contract). Do not log full request URLs or enable payload debug logging in production.
+
 ## INSTALLATION
 Before installing the wrapper, you have to make sure that `CMake` is installed on your system. It can be downloaded from [here](https://cmake.org/download/).
 

--- a/include/ZeroBounce/ZeroBounce.h
+++ b/include/ZeroBounce/ZeroBounce.h
@@ -95,19 +95,19 @@ class BaseRequestHandler {
 class RequestHandler : public BaseRequestHandler {
     protected:
         cpr::Response doGet(const cpr::Url& url) {
-            return cpr::Get(url);
+            return cpr::Get(url, cpr::Timeout{120000});
         }
         cpr::Response doGet(const cpr::Url& url, const cpr::Header& header) {
-            return cpr::Get(url, header);
+            return cpr::Get(url, header, cpr::Timeout{120000});
         }
         cpr::Response doGetWithParameters(const cpr::Url& url, const cpr::Parameters& parameters) {
-            return cpr::Get(url, parameters);
+            return cpr::Get(url, parameters, cpr::Timeout{120000});
         }
         cpr::Response doPost(const cpr::Url& url, const cpr::Header& header, const cpr::Body& body) {
-            return cpr::Post(url, header, body);
+            return cpr::Post(url, header, body, cpr::Timeout{120000});
         }
         cpr::Response doPost(const cpr::Url& url, const cpr::Header& header, const cpr::Multipart& multipart) {
-            return cpr::Post(url, header, multipart);
+            return cpr::Post(url, header, multipart, cpr::Timeout{120000});
         }
 };
 


### PR DESCRIPTION
## Summary

- `cpr::Timeout{120000}` on GET/POST
- README Security notes

This is **not** a version bump or registry publish. Cut a separate `release-sdk` pass after merge if the hardening should ship to package registries.

## Test plan

- [ ] SDK unit tests (Docker matrix / host for iOS)
- [ ] Confirm no live API key is logged or committed
- [ ] Confirm custom `http://` / `file:` base URLs are rejected (except documented loopback test exceptions)


Made with [Cursor](https://cursor.com)